### PR TITLE
Reset user's parameters in displayRaster

### DIFF
--- a/R/display.R
+++ b/R/display.R
@@ -47,7 +47,8 @@ displayRaster = function(image, frame, all = FALSE, drawGrid = TRUE, ...){
   yran = c(0, nrow*ydim) + .5
   
   ## set graphical parameters
-  par(bty="n", mai=c(0,0,0,0), xaxs="i", yaxs="i", xaxt="n", yaxt="n")    
+  user <- par(bty="n", mai=c(0,0,0,0), xaxs="i", yaxs="i", xaxt="n", yaxt="n")
+  on.exit(par(user))
   plot(xran, yran, type="n", xlab="", ylab="", asp=1, ylim=rev(yran))
       
   for(r in seq_len(nrow)) {


### PR DESCRIPTION
displayRaster modifies the users graphical parameter settings with a call to `par`. This commit saves the users parameter settings and restores them on exit from displayRaster.

```r
library(EBImage)
f = system.file("images", "sample.png", package="EBImage")
img = readImage(f)

# This plot should look the same before ...
plot(1:10)

display(img, method = "raster")

# ... and after displaying an image
plot(1:10)
```