### PR TITLE
Adding bg option to watershed

### DIFF
--- a/R/segment.R
+++ b/R/segment.R
@@ -1,11 +1,13 @@
 ## - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-watershed = function (x, tolerance=1, ext=1) {
+watershed = function (x, tolerance=1, ext=1, bg=0) {
   validImage(x)
   tolerance = as.numeric(tolerance)
   if (tolerance<0) stop( "'tolerance' must be non-negative" )
   ext = as.integer(ext)
+  bg = as.numeric(bg)
   if (ext<1) stop( "'ext' must be a positive integer" )
-  .Call(C_watershed, castImage(x), tolerance, ext)
+  if (bg<0) stop( "'bg' must be non-negative" )
+  .Call(C_watershed, castImage(x), tolerance, ext, bg)
 }
 
 ## - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/man/watershed.Rd
+++ b/man/watershed.Rd
@@ -12,7 +12,7 @@
 }
 
 \usage{
-watershed(x, tolerance=1, ext=1)
+watershed(x, tolerance=1, ext=1, bg=0)
 }
 
 \arguments{
@@ -29,6 +29,9 @@ watershed(x, tolerance=1, ext=1)
 
   \item{ext}{Radius of the neighborhood in pixels for the detection
     of neighboring objects. Higher value smoothes out small objects. }
+
+  \item{bg}{Background value under which pixels are not considered
+    anymore for watersheding.}
 }
 
 \value{

--- a/src/EBImage.c
+++ b/src/EBImage.c
@@ -43,7 +43,7 @@ static R_CallMethodDef CallEntries[] = {
     CALLDEF(bwlabel, 1),
     CALLDEF(normalize, 4),
     CALLDEF(distmap, 2),
-    CALLDEF(watershed, 3),
+    CALLDEF(watershed, 4),
     CALLDEF(propagate, 4),
     CALLDEF(paintObjects, 5),
     CALLDEF(rmObjects, 3),

--- a/src/watershed.h
+++ b/src/watershed.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-SEXP watershed(SEXP, SEXP, SEXP);
+SEXP watershed(SEXP, SEXP, SEXP, SEXP);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The work in this pull request comes from the fact that we are currently doing a watershed over slightly big images that need to be filtered first to cancel out some background noise.

To do that we do something like this:

```
> image[image < 1.5] = 0
> EBImage::watershed(image, tolerance=0)
```

The problem is that the cost of doing this filtering ourselves is a fair amount of the total cost:

```
> dim(image)
[1] 2848 2848

> microbenchmark({image[image < 1.5]=0}, times=100)
Unit: milliseconds
                       expr     min      lq     mean   median       uq     max neval
 { image[image < 1.5] = 0 } 62.7114 70.7209 105.7809 88.69216 101.6094 276.556   100

> microbenchmark(EBImage::watershed(image, tolerance = 0))
Unit: milliseconds
                                     expr      min       lq     mean   median       uq      max neval
 EBImage::watershed(image, tolerance = 0) 629.0318 660.6444 687.8925 676.6159 699.1388 865.2657   100
```

Based on the median and mean values of these measurements we are observing an approximate filtering cost of 10%-15%.

Doing the watershed with the internal filtering (what we are proposing in this pull request) we should be able to do:

```
> EBImage::watershed(image, tolerance = 0, bg=1.5)
```

The cost is negligible, as the current watershed algorithm is already filtering positive pixels:

```
> microbenchmark(EBImage::watershed(image, tolerance = 0, bg=1.5))
Unit: milliseconds
                                          expr      min       lq     mean   median       uq      max neval
 EBImage::watershed(image, tolerance=0, bg=1.5) 581.5359 645.1499 664.3851 660.9021 675.6802 770.4231   100
```