### PR TITLE
use length.out with seq

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: EBImage
-Version: 4.38.0
+Version: 4.39.0
 Title: Image processing and analysis toolbox for R
 Encoding: UTF-8
 Author: Andrzej Oleś, Gregoire Pau, Mike Smith, Oleg Sklyar, Wolfgang Huber, with contributions from Joseph Barry and Philip A. Marais

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: EBImage
-Version: 4.35.2
+Version: 4.36.0
 Title: Image processing and analysis toolbox for R
 Encoding: UTF-8
 Author: Andrzej Oleś, Gregoire Pau, Mike Smith, Oleg Sklyar, Wolfgang Huber, with contributions from Joseph Barry and Philip A. Marais

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: EBImage
-Version: 4.36.0
+Version: 4.37.0
 Title: Image processing and analysis toolbox for R
 Encoding: UTF-8
 Author: Andrzej Oleś, Gregoire Pau, Mike Smith, Oleg Sklyar, Wolfgang Huber, with contributions from Joseph Barry and Philip A. Marais

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: EBImage
-Version: 4.37.0
+Version: 4.38.0
 Title: Image processing and analysis toolbox for R
 Encoding: UTF-8
 Author: Andrzej Oleś, Gregoire Pau, Mike Smith, Oleg Sklyar, Wolfgang Huber, with contributions from Joseph Barry and Philip A. Marais

--- a/R/Image.R
+++ b/R/Image.R
@@ -646,7 +646,7 @@ setMethod ("hist", signature(x="Image"),
 
     if(length(breaks)==1L) {
       bins = breaks
-      breaks = seq(rg[1], rg[2], length=breaks+1L)
+      breaks = seq(rg[1], rg[2], length.out=breaks+1L)
     } else {
       bins = length(breaks) - 1L
     }

--- a/R/morphology.R
+++ b/R/morphology.R
@@ -59,7 +59,7 @@ makeBrush = function(size, shape=c('box', 'disc', 'diamond', 'Gaussian', 'line')
     }
   }
   else if (shape=='gaussian') {
-    x = seq(-(size-1)/2, (size-1)/2, length=size)
+    x = seq(-(size-1)/2, (size-1)/2, length.out=size)
     x = matrix(x, size, size)
     z = exp(- (x^2 + t(x)^2) / (2*sigma^2))
     z = z / sum(z)

--- a/man/Image.Rd
+++ b/man/Image.Rd
@@ -136,7 +136,7 @@ numberOfFrames(y, type = c('total', 'render'))
   x = Image(rnorm(300*300*3),dim=c(300,300,3), colormode='Color')
   display(x)
 
-  w = matrix(seq(0, 1, len=300), nc=300, nr=300)
+  w = matrix(seq(0, 1, length.out=300), nc=300, nr=300)
   m = abind::abind(w, t(w), along=3)
   z = Image(m, colormode='Color')
   display(normalize(z))

--- a/man/combine.Rd
+++ b/man/combine.Rd
@@ -56,7 +56,7 @@ combine(x, y, ...)
   ## Blurred images
   x = resize(img, 128, 128)
   xt = list()
-  for (t in seq(0.1, 5, len=9)) xt=c(xt, list(gblur(x, s=t)))
+  for (t in seq(0.1, 5, length.out=9)) xt=c(xt, list(gblur(x, s=t)))
   xt = combine(xt)
   display(xt, title='Blurred images', all=TRUE)
 }

--- a/man/tile.Rd
+++ b/man/tile.Rd
@@ -47,7 +47,7 @@ untile(x, nim, lwd=1)
   img = readImage(system.file("images", "sample-color.png", package="EBImage"))[257:768,,]
   x = resize(img, 128, 128)
   xt = list()
-  for (t in seq(0.1, 5, len=9)) xt=c(xt, list(gblur(x, s=t)))
+  for (t in seq(0.1, 5, length.out=9)) xt=c(xt, list(gblur(x, s=t)))
   xt = combine(xt)
   display(xt, title='Blurred images')
 


### PR DESCRIPTION
Hi Andrzej, @aoles 

Some `seq` calls are not using the full argument `length.out`. I've updated these calls in the PR. 
Note. I am using the latest checkout from Bioconductor.

Best,
Marcel